### PR TITLE
Add Magic function __get()

### DIFF
--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -414,7 +414,19 @@ class ParserDom {
 		}
 		unset($node);
 	}
+	function __get($name)
+	{
+		switch ($name)
+		{
+			case 'outertext':
+				return $this->outerHtml();
+			case 'innertext':
+				return $this->innerHtml();
+			case 'plaintext':
+				return $this->getPlainText();
 
+		}
+	}
 }
 
 ?>


### PR DESCRIPTION
Add Magic function __get to make this library works like original idea - PHP Simple Dom Parser. Now you can use like this $example->plaintext, $example->outertext, $example->innertext