### PR TITLE
Add setAttr() and save()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,162 +1,269 @@
-HtmlParser
-===============
+**PHP DOM HTML Parser** uses built-in [PHP DOM extension](http://php.net/manual/en/book.dom.php) to process your requests, after testing, it is 10x faster than [PHP Simple HTML DOM Parser](http://simplehtmldom.sourceforge.net/)
 
-[![Build Status](https://api.travis-ci.org/bupt1987/html-parser.svg)](https://travis-ci.org/bupt1987/html-parser)  
+PHP DOM extension requires the libxml PHP extension. This means that passing in --enable-libxml is also required, although this is implicitly accomplished because libxml is enabled by default.
 
-php html解析工具，类似与PHP Simple HTML DOM Parser。
-由于基于php模块dom，所以在解析html时的效率比 PHP Simple HTML DOM Parser 快好几倍。
+# Examples
 
+***
 
-注意：html代码必须是utf-8编码字符，如果不是请转成utf-8  
-      如果有乱码的问题参考：http://www.fwolf.com/blog/post/314  
+## Getting Started
 
-现在支持composer
+```php
+$html = '<div>
+test this library! <a href="https://github.com/shinbonlin">PHP DOM HTML Parser</a>
+</div><div class="example">test string!</div>
+```
 
-"require": {"bupt1987/html-parser": "dev-master"}
-
-加载composer  
-require 'vendor/autoload.php';
-
-================================================================================
-##### *Example*
-~~~
-<?php
-require 'vendor/autoload.php';
-
-$html = '<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title>test</title>
-  </head>
-  <body>
-    <p class="test_class test_class1">p1</p>
-    <p class="test_class test_class2">p2</p>
-    <p class="test_class test_class3">p3</p>
-    <div id="test1">测试1</div>
-  </body>
-</html>';
+if you use Namespace
+```php
 $html_dom = new \HtmlParser\ParserDom($html);
-$p_array = $html_dom->find('p.test_class');
-$p1 = $html_dom->find('p.test_class1',0);
-$div = $html_dom->find('div#test1',0);
-foreach ($p_array as $p){
-	echo $p->getPlainText() . "\n";
+```
+
+If you comment out the Namespace in line:2
+```php
+$html_dom = new ParserDom($html);
+```
+
+***
+
+## Basic
+
+Find all images
+```php
+foreach($html_dom->find('img') as $element) {
+       echo $element->src . '<br>';
+       echo $element->getAttr('src') . '<br>';
 }
-echo $div->getPlainText() . "\n";
-echo $p1->getPlainText() . "\n";
-echo $p1->getAttr('class') . "\n";
-echo "show html:\n";
-echo $div->innerHtml() . "\n";
-echo $div->outerHtml() . "\n";
-?>
-~~~
+```
 
-基础用法
-================================================================================
-~~~
-// 查找所有a标签
-$ret = $html->find('a');
+Find all links 
+```php
+foreach($html_dom->find('a') as $element) {
+       echo $element->href . '<br>';
+       echo $element->getAttr('href') . '<br>';
+}
+```
 
-// 查找a标签的第一个元素
-$ret = $html->find('a', 0);
+Find all anchors, returns a array of element objects
+```php
+$ret = $html_dom->find('a');
+```
 
-// 查找a标签的倒数第一个元素
-$ret = $html->find('a', -1); 
+Find (N)th anchor, returns element object or null if not found (zero based)
+```php
+$ret = $html_dom->find('a', 0);
+```
 
-// 查找所有含有id属性的div标签
-$ret = $html->find('div[id]');
+Find lastest anchor, returns element object or null if not found (zero based)
+```php
+$ret = $html_dom->find('a', -1); 
+```
 
-// 查找所有含有id属性为foo的div标签
-$ret = $html->find('div[id=foo]');
+Find all `<div>` with the id attribute
+```php
+$ret = $html_dom->find('div[id]');
+```
 
-// 设置属性
-$ret = $html->find('a', 0);
-$ret->setAttr('href', 'example url');
+Find all `<div>` which attribute id=foo
+```php
+$ret = $html_dom->find('div[id=foo]');
+```
+## Advanced
 
-// 储存已修改过的DOM本文
-$data = $html->save();
-~~~
+Find all element which id=foo
+```php
+$ret = $html_dom->find('#foo');
+```
 
-高级用法
-================================================================================
-~~~
-// 查找所有id=foo的元素
-$ret = $html->find('#foo');
+Find all element which class=foo
+```php
+$ret = $html_dom->find('.foo');
+```
 
-// 查找所有class=foo的元素
-$ret = $html->find('.foo');
+Find all HTML tags with the id attribute
+```php
+$ret = $html_dom->find('*[id]');
+```
 
-// 查找所有拥有 id属性的元素
-$ret = $html->find('*[id]'); 
+Find all anchors and images
+```php
+$ret = $html_dom->find('a, img');
+```
 
-// 查找所有 anchors 和 images标记 
-$ret = $html->find('a, img'); 
+Find all anchors and images with the "title" attribute
+```php
+$ret = $html_dom->find('a[title], img[title]');
+```
+## Descendant Seletors
 
-// 查找所有有"title"属性的anchors and images 
-$ret = $html->find('a[title], img[title]');
-~~~
+Find all `<li>` in `<ul> `
+```php
+$es = $html_dom->find('ul li');
+```
 
-层级选择器
-================================================================================
-~~~
-// Find all <li> in <ul> 
-$es = $html->find('ul li');
+Find Nested <div> tags
+```php
+$es = $html_dom->find('div div div'); 
+```
 
-// Find Nested <div> tags
-$es = $html->find('div div div'); 
+Find all `<td>` in `<table>` which class=hello
+```php
+$es = $html_dom->find('table.hello td');
+```
 
-// Find all <td> in <table> which class=hello 
-$es = $html->find('table.hello td');
+Find all td tags with attribite align=center in table tags 
+```php
+$es = $html_dom->find('table td[align=center]');
+```
 
-// Find all td tags with attribite align=center in table tags 
-$es = $html->find('table td[align=center]'); 
-~~~
+***
 
-嵌套选择器
-================================================================================
-~~~
-// Find all <li> in <ul> 
-foreach($html->find('ul') as $ul) 
-{
-       foreach($ul->find('li') as $li) 
-       {
+## Modify HTML 
+
+Modify class attribute
+```php
+$html_dom->find('div', 1)->class = 'bar';
+```
+
+Modify inner text (HTML is allowed)
+```php
+$html_dom->find('div[id=hello]', 0)->innertext = 'foo';
+```
+
+Modify outer HTML
+```php
+// this example will remove (destory) `<a>` element and replace with new element `<h1>` 
+$html_dom->find('a', 0)->outertext = '<h1>Title Link</h1>';
+```
+
+***
+
+## Nested Selectors
+
+Find all `<li>` in `<ul>`
+```php
+foreach($html_dom->find('ul') as $ul) {
+       foreach($ul->find('li') as $li) {
              // do something...
        }
 }
+```
 
-// Find first <li> in first <ul> 
-$e = $html->find('ul', 0)->find('li', 0);
-~~~
+Find first `<li>` in first `<ul>` 
+```php
+$e = $html_dom->find('ul', 0)->find('li', 0);
+```
 
-属性过滤
-================================================================================
-~~~
-支持属性选择器操作:
+***
 
-过滤	描述
-[attribute]	匹配具有指定属性的元素.
-[!attribute]	匹配不具有指定属性的元素。
-[attribute=value]	匹配具有指定属性值的元素
-[attribute!=value]	匹配不具有指定属性值的元素
-[attribute^=value]	匹配具有指定属性值开始的元素
-[attribute$=value]	匹配具有指定属性值结束的元素
-[attribute*=value]	匹配具有指定属性的元素,且该属性包含了一定的值
-~~~
+## Attribute Selectors
 
-Dom扩展用法
-===============================================================================
-~~~
-获取dom通过扩展实现更多的功能，详见：http://php.net/manual/zh/book.dom.php
+Filter | Description
+------------ | -------------
+[attribute] | Matches elements that have the specified attribute.
+[!attribute] | Matches elements that don't have the specified attribute.
+[attribute=value] | Matches elements that have the specified attribute with a certain value.
+[attribute!=value] | Matches elements that don't have the specified attribute with a certain value.
+[attribute^=value] | Matches elements that have the specified attribute and it starts with a certain value.
+[attribute$=value] | Matches elements that have the specified attribute and it ends with a certain value.
+[attribute*=value] | Matches elements that have the specified attribute and it contains a certain value.
 
-/**
- * @var \DOMNode
- */
-$oHtml->node
+***
 
-$oHtml->node->childNodes
-$oHtml->node->parentNode
-$oHtml->node->firstChild
-$oHtml->node->lastChild
-等等...
+## Magic Attribute
 
-~~~
+```php
+// Example HTML: <div class="blue-color">foo <b>bar</b></div> 
+$e = $html_dom->find("div", 0);
+
+echo $e->outertext; // Returns: "<div class="blue-color">foo <b>bar</b></div>"
+echo $e->innertext; // Returns: "foo <b>bar</b>"
+echo $e->plaintext; // Returns: "foo bar"
+echo $e->tag; // Returns: "div" (current tag name)
+echo $e->class; // Returns: "blue-color" 
+```
+
+Attribute Name | Usage
+------------ | -------------
+$e->outertext | Read or write the outer HTML text of element.
+$e->innertext | Read or write the inner HTML text of element.
+$e->plaintext | Read or write the plain text of element.
+$e->tag | Read current tag name of element.
+$e->src | Read or write  "src" attribute of element.
+$e->class | Read or write  "class" attribute of element.
+$e->href | Read or write  "href" attribute of element.
+
+Except outertext, innertext and plaintext, you can use $e->attribute_name to read or write attribute of element.
+
+***
+
+## More Examples
+
+Get a attribute ( If the attribute is non-value attribute (eg. checked, selected...), it will returns true or false)
+```php
+$value = $e->href;
+```
+
+Set a attribute(If the attribute is non-value attribute (eg. checked, selected...), set it's value as true or false)
+```php
+$e->href = 'my link';
+```
+
+Remove a attribute, set it's value as null! 
+```php
+$e->href = null;
+```
+
+Determine whether a attribute exist? 
+```php
+if (isset($e->href)) echo 'href exist!';
+```
+
+Extract contents from HTML
+```php
+echo $html->plaintext;
+```
+
+Wrap a element
+```php
+$e->outertext = '<div class="wrap">' . $e->outertext . '<div>';
+```
+
+Remove a element, set it's outertext as an empty string 
+```php
+$e->outertext = '';
+```
+
+Append a element
+```php
+$e->outertext = $e->outertext . '<div>foo<div>';
+```
+
+Insert a element
+$e->outertext = '<div>foo<div>' . $e->outertext;
+```
+
+Dumps the internal DOM tree back into string
+```php
+$str = $html_dom->save();
+```
+
+Dumps the internal DOM tree back into a file
+```php 
+$html_dom->save('result.htm');
+```
+
+***
+
+## Extension
+
+You can use PHP DOM extension as the following code:
+```php 
+$html_dom->node
+
+$html_dom->node->childNodes
+$html_dom->node->parentNode
+$html_dom->node->firstChild
+$html_dom->node->lastChild
+```
+For more information, please visit [http://php.net/manual/en/book.dom.php](http://php.net/manual/en/book.dom.php)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#PHP DOM HTML Parser
+
 **PHP DOM HTML Parser** uses built-in [PHP DOM extension](http://php.net/manual/en/book.dom.php) to process your requests, after testing, it is 10x faster than [PHP Simple HTML DOM Parser](http://simplehtmldom.sourceforge.net/)
 
 PHP DOM extension requires the libxml PHP extension. This means that passing in --enable-libxml is also required, although this is implicitly accomplished because libxml is enabled by default.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PHP DOM extension requires the libxml PHP extension. This means that passing in 
 ```php
 $html = '<div>
 test this library! <a href="https://github.com/shinbonlin">PHP DOM HTML Parser</a>
-</div><div class="example">test string!</div>
+</div><div class="example">test string!</div>';
 ```
 
 if you use Namespace

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Dumps the internal DOM tree back into a file
 $html_dom->save('result.htm');
 ```
 
+## Free memory
+
+Script will free memory automatically, however, if you would like to do it manually
+```php 
+$html_dom->clear();
+```
 
 ## Extension
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 PHP DOM extension requires the libxml PHP extension. This means that passing in --enable-libxml is also required, although this is implicitly accomplished because libxml is enabled by default.
 
-# Examples
-
 ***
 
 ## Getting Started
@@ -26,7 +24,6 @@ If you comment out the Namespace in line:2
 $html_dom = new ParserDom($html);
 ```
 
-***
 
 ## Basic
 
@@ -118,7 +115,6 @@ Find all td tags with attribite align=center in table tags
 $es = $html_dom->find('table td[align=center]');
 ```
 
-***
 
 ## Modify HTML 
 
@@ -138,7 +134,6 @@ Modify outer HTML
 $html_dom->find('a', 0)->outertext = '<h1>Title Link</h1>';
 ```
 
-***
 
 ## Nested Selectors
 
@@ -156,7 +151,6 @@ Find first `<li>` in first `<ul>`
 $e = $html_dom->find('ul', 0)->find('li', 0);
 ```
 
-***
 
 ## Attribute Selectors
 
@@ -170,7 +164,6 @@ Filter | Description
 [attribute$=value] | Matches elements that have the specified attribute and it ends with a certain value.
 [attribute*=value] | Matches elements that have the specified attribute and it contains a certain value.
 
-***
 
 ## Magic Attribute
 
@@ -197,7 +190,6 @@ $e->href | Read or write  "href" attribute of element.
 
 Except outertext, innertext and plaintext, you can use $e->attribute_name to read or write attribute of element.
 
-***
 
 ## More Examples
 
@@ -255,7 +247,6 @@ Dumps the internal DOM tree back into a file
 $html_dom->save('result.htm');
 ```
 
-***
 
 ## Extension
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ $e->outertext = $e->outertext . '<div>foo<div>';
 ```
 
 Insert a element
+```php
 $e->outertext = '<div>foo<div>' . $e->outertext;
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ $ret = $html->find('a', -1);
 $ret = $html->find('div[id]');
 
 // 查找所有含有id属性为foo的div标签
-$ret = $html->find('div[id=foo]'); 
+$ret = $html->find('div[id=foo]');
+
+// 設置屬性
+$ret = $html->find('a', 0);
+$ret->setAttr('href', 'example url');
+
+// 儲存已修改過的DOM本文
+$data = $html->save();
 ~~~
 
 高级用法

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ $ret = $html->find('div[id]');
 // 查找所有含有id属性为foo的div标签
 $ret = $html->find('div[id=foo]');
 
-// 設置屬性
+// 设置属性
 $ret = $html->find('a', 0);
 $ret->setAttr('href', 'example url');
 
-// 儲存已修改過的DOM本文
+// 储存已修改过的DOM本文
 $data = $html->save();
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Dumps the internal DOM tree back into a file
 $html_dom->save('result.htm');
 ```
 
-## Free memory
+## Free Memory
 
 Script will free memory automatically, however, if you would like to do it manually
 ```php 

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -243,7 +243,6 @@ class ParserDom {
 					$f = $parentNode->ownerDocument->createDocumentFragment();
 					$result = @$f->appendXML($value);
 					if ($result) {
-						echo '1****************1';
 						if ($parentNode->hasChildNodes()) {
 							$parentNode->replaceChild($f, $parentNode->childNodes->item($x));
 						}

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -170,12 +170,19 @@ class ParserDom {
 	 */
 	public function innerHtml($value = null) {
 		if ($value == null) {
-			$innerHTML = "";
-			$children = $this->node->childNodes;
-			foreach ($children as $child) {
-				$innerHTML .= $this->node->ownerDocument->saveHTML($child) ?: '';
+			if ( !is_null($value) ) {
+				// give a empty string, you want me destory this element!
+				for ($x = $this->node->childNodes->length-1; $x >= 0; $x--) {
+					$this->node->removeChild($this->node->childNodes->item($x));
+				}
+			} else {
+				$innerHTML = "";
+				$children = $this->node->childNodes;
+				foreach ($children as $child) {
+					$innerHTML .= $this->node->ownerDocument->saveHTML($child) ?: '';
+				}
+				return $innerHTML;
 			}
-			return $innerHTML;
 		} else {
 			// Original code by Keyvan Minoukadeh <keyvan@keyvan.net>,
 			// integrated by Shinbon Lin.
@@ -215,10 +222,21 @@ class ParserDom {
 	 */
 	public function outerHtml($value = null) {
 		if ($value == null) {
-			$doc = new \DOMDocument();
-			$doc->appendChild($doc->importNode($this->node, true));
-			return $doc->saveHTML($doc);
+			if ( !is_null($value) ) {
+				// give a empty string, you want me destory this element!
+				$parentNode = $this->getParent($this->node);
+				for ($x = $parentNode->childNodes->length-1; $x >= 0; $x--) {
+					if ($this->node->isSameNode($parentNode->childNodes->item($x))) {
+						$parentNode->removeChild($parentNode->childNodes->item($x));
+					}
+				}
+			} else {
+				$doc = new \DOMDocument();
+				$doc->appendChild($doc->importNode($this->node, true));
+				return $doc->saveHTML($doc);
+			}
 		} else {
+
 			$parentNode = $this->getParent($this->node);
 			for ($x = $parentNode->childNodes->length-1; $x >= 0; $x--) {
 				if ($this->node->isSameNode($parentNode->childNodes->item($x))) {

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -295,7 +295,11 @@ class ParserDom {
 	 * @return string|null
 	 */
 	public function setAttr($name, $value) {
-		$this->node->setAttribute($name, $value);
+		if ($value === null) {
+			$this->node->removeAttribute($name);
+		} else {
+			$this->node->setAttribute($name, $value);
+		}
 		return null;
 	}
 

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -516,7 +516,7 @@ class ParserDom {
 	}
 	/**
 	 * @codeCoverageIgnore
-	 * 释放内存
+	 * 释放内存 Automatically free memory
 	 *
 	 * @param $node
 	 */
@@ -527,6 +527,13 @@ class ParserDom {
 			}
 		}
 		unset($node);
+	}
+	/**
+	 * Manually free memory
+	 */
+
+	public function clear() {
+		$this->clearNode($this->node);
 	}
 	/**
 	 * 将处理后的Dom输出

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -429,19 +429,57 @@ class ParserDom {
 		}
 		unset($node);
 	}
-	function __get($name)
-	{
-		switch ($name)
-		{
+	/**
+	 * 将处理后的Dom输出
+	 * Export changed Dom into string
+	 * 支援 PHP Simple Dom 的习惯用法
+	 * for supporting usage of PHP Simple DOM Parser
+	 *
+	 * @param boolean $strip
+	 * @return string
+	 */
+	public function save($strip = true) {
+		if ($strip) {
+			$this->strip_html_container($this->node);
+			return $this->node->saveHTML();
+		} else {
+			return $this->node->saveHTML();
+		}
+	}
+	/**
+	 * 去除因 loadHTML() 自行添加的外部HTML容器
+	 * Strip HTML container created by loadHTML()
+	 *
+	 * @param \DOMNode $node
+	 */
+	private function strip_html_container(&$node) {
+		$container = $node->getElementsByTagName('body')->item(0);
+		$container = $container->parentNode->removeChild($container);
+		while ($node->firstChild) {
+			$node->removeChild($node->firstChild);
+		}
+		while ($container->firstChild ) {
+			$node->appendChild($container->firstChild);
+		}
+	}
+	/**
+	 * Magic methods - for supporting usage of PHP Simple Dom Parser
+	 * 支援 PHP Simple Dom 的习惯用法
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	function __get($name) {
+		switch ($name) {
 			case 'outertext':
 				return $this->outerHtml();
 			case 'innertext':
 				return $this->innerHtml();
 			case 'plaintext':
 				return $this->getPlainText();
-
 		}
 	}
+
 }
 
 ?>

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -189,10 +189,25 @@ class ParserDom {
 	 * @return string|null
 	 */
 	public function getAttr($name) {
-		$oAttr = $this->node->attributes->getNamedItem($name);
+		//$oAttr = $this->node->attributes->getNamedItem($name);
+		$oAttr = $this->node->getAttribute($name);
+
 		if (isset($oAttr)) {
-			return $oAttr->nodeValue;
+			//return $oAttr->nodeValue;
+			return $oAttr;
 		}
+		return null;
+	}
+
+	/**
+	 * 设置html的元属值
+	 *
+	 * @param string $name
+	 * @param string $value
+	 * @return string|null
+	 */
+	public function setAttr($name, $value) {
+		$this->node->setAttribute($name, $value);
 		return null;
 	}
 

--- a/src/ParserDom.php
+++ b/src/ParserDom.php
@@ -484,7 +484,15 @@ class ParserDom {
 	private function getParent($node) {
 		return $node->parentNode;
 	}
-
+	
+	/**
+	 * 获取Tag名
+	 *
+	 * @return string
+	 */
+	public function getTag() {
+		return $this->node->nodeName;
+	}
 	/**
 	 * @codeCoverageIgnore
 	 * 释放内存
@@ -547,6 +555,8 @@ class ParserDom {
 				return $this->innerHtml();
 			case 'plaintext':
 				return $this->getPlainText();
+			case 'tag':
+				return $this->getTag();
 			default:
 				return $this->getAttr($name);
 		}
@@ -568,6 +578,8 @@ class ParserDom {
 				break;
 			case 'plaintext':
 				$this->getPlainText($value);
+				break;
+			case 'tag':
 				break;
 			default:
 				$this->setAttr($name, $value);


### PR DESCRIPTION
Add setAttr() to support setting attribute

增加setAttr()方法，整合getAttr()的取值方式，例：

$tag_blocks->find('a.post-tag', 0);
$tag->setAttr('href', 'your url');
// test
echo $tag->getAttr('href'); // result: your url

**增加储存本文功能 Add function save()**

增加储存本文功能，经过修改后的DOM本文能储存并输出为字串
Add function save() to store modified DOM and could be exported into a string variable .

for example:

$dom_html = new ParserDom($get_dom_html);
echo $dom_html->save();